### PR TITLE
FraxFamilialGaugeDistributor

### DIFF
--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -170,6 +170,9 @@ contract FraxFamilialGaugeDistributor is Owned {
             (weeks_elapsed, reward_tally) = IFraxGaugeFXSRewardsDistributor(rewards_distributor).distributeReward(address(this));
             emit FamilialRewardClaimed(address(this), weeks_elapsed, reward_tally);
 
+            // ensure that reward_tally == the amount of FXS held in this contract
+            require(reward_tally == IERC20(reward_token).balanceOf(address(this)), "tally!=balance");
+            
             // divide the reward_tally amount by the gauge's allocation to get the allocation
             for (uint256 i; i < gauges.length; i++) {
                 if (gauge_active[gauges[i]]) { 
@@ -198,6 +201,7 @@ contract FraxFamilialGaugeDistributor is Owned {
             }
 
             ////////// FINALLY - all other farms are updated, let the calling farm finish execution //////////
+            /// @dev: this contract, after execution through each child farm, should not retain any token!
         }
 
         // preserve the gauge's reward tally for returning to the gauge

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.17;
 // ======================== FraxMiddlemanGauge ========================
 // ====================================================================
 /**
-*   @title FraxFamilialPitchGauge
+*   @title FraxFamilialGaugeDistributor
 *   @notice Redistributes gauge rewards to multiple gauges (FraxFarms) based on each "child" gauge's `total_combined_weight`.
 *   @author Modified version of the FraxMiddlemanGauge - by ZrowGz @ Pitch Foundation
 *   @dev To use this:
@@ -31,7 +31,7 @@ import "../Staking/Owned.sol";
 import "../Staking/IFraxFarm.sol";
 import "./IFraxGaugeControllerV2.sol";
 
-contract FraxFamilialGaugeDistributor is Owned {//, ReentrancyGuard {
+contract FraxFamilialGaugeDistributor is Owned {
     /* ========== STATE VARIABLES ========== */
     /// Note: variables made internal for execution gas savings, available through getters below
 
@@ -46,7 +46,8 @@ contract FraxFamilialGaugeDistributor is Owned {//, ReentrancyGuard {
     /// @notice Address of the FXS Rewards Distributor
     address internal immutable rewards_distributor;
     /// @notice Address of the rewardToken
-    address internal immutable reward_token;// = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0; // FXS
+    // address internal immutable reward_token;// = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0; // FXS
+    address internal constant reward_token = address(0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0); // FXS
 
     ///// Familial Gauge Storage /////
     /// @notice Array of all child gauges
@@ -96,8 +97,8 @@ contract FraxFamilialGaugeDistributor is Owned {//, ReentrancyGuard {
         address _owner,
         address _timelock_address,
         address _rewards_distributor,
-        address _gauge_controller,
-        address _reward_token
+        address _gauge_controller//,
+        // address _reward_token
     ) Owned(_owner) {
         timelock_address = _timelock_address;
 
@@ -106,7 +107,7 @@ contract FraxFamilialGaugeDistributor is Owned {//, ReentrancyGuard {
         name = _name;
 
         gauge_controller = _gauge_controller;
-        reward_token = _reward_token;
+        // reward_token = _reward_token;
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -147,7 +147,7 @@ contract FraxFamilialGaugeDistributor is Owned {
 
             // get the familial vote weight for this period
             total_familial_relative_weight = 
-                IFraxGaugeController(gauge_controller).gauge_relative_weight_write(address(this), timestamp);
+                IFraxGaugeController(gauge_controller).gauge_relative_weight_write(address(this), block.timestamp);
 
             // update all the gauge weights
             for (uint256 i; i < gauges.length; i++) {

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -71,6 +71,8 @@ contract FraxFamilialGaugeDistributor is Owned {
     mapping(address => uint256) internal gauge_to_total_combined_weight;
     
     // Distributor provided 
+    /// @notice The timestamp of the vote period
+    // uint256 public weeks_elapsed;
     /// @notice The amount of FXS awarded to the family by the vote, from the Distributor
     uint256 public reward_tally;
     /// @notice The redistributed FXS rewards payable to each child gauge

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -80,7 +80,7 @@ contract FraxFamilialGaugeDistributor is Owned {
 
     // Reward period & Time tracking
     /// @notice The timestamp of the last reward period
-    uint256 internal periodFinish;
+    // uint256 internal periodFinish;
     /// @notice The number of seconds in a week
     uint256 internal constant rewardsDuration = 604800; // 7 * 86400  (7 days)
 
@@ -94,7 +94,7 @@ contract FraxFamilialGaugeDistributor is Owned {
     /* ========== CONSTRUCTOR ========== */
 
     constructor (
-        string calldata _name,
+        string memory _name,
         address _owner,
         address _timelock_address,
         address _rewards_distributor,
@@ -183,12 +183,12 @@ contract FraxFamilialGaugeDistributor is Owned {
                 }
             }
 
-            // call `sync_gauge_weights` on the other gauges
-            for (uint256 i; i < gauges.length; i++) {
-                if (gauges[i] != child_gauge && gauge_active[gauges[i]]) {
-                    IFraxFarm(gauges[i]).sync_gauge_weights(true);
-                }
-            }
+            // // call `sync_gauge_weights` on the other gauges
+            // for (uint256 i; i < gauges.length; i++) {
+            //     if (gauges[i] != child_gauge && gauge_active[gauges[i]]) {
+            //         IFraxFarm(gauges[i]).sync_gauge_weights(true);
+            //     }
+            // }
 
             ////////// THIRD - trigger all child gauges to call this contract //////////
 
@@ -212,14 +212,14 @@ contract FraxFamilialGaugeDistributor is Owned {
         TransferHelper.safeTransfer(reward_token, child_gauge, claimingGaugeRewardAmount);
         
         // Update the child farm reward vars: reward token, the reward rate/tally, zero address for gauge controller, this address as distributor
-        IFraxFarm(child_gauge).setRewardRates(rewardToken, (claimingGaugeRewardAmount / rewardsDuration), address(0), address(this));
+        IFraxFarm(child_gauge).setRewardVars(reward_token, (claimingGaugeRewardAmount / rewardsDuration), address(0), address(this));
         
         // reset the reward tally to zero for the gauge
         gauge_to_reward_amount[child_gauge] = 0;
         emit ChildGaugeRewardDistributed(child_gauge, claimingGaugeRewardAmount);
 
         // the farm doesn't actually write this anywhere
-        return (weeks_elapsed, claimingGaugeRewardRate);
+        return (weeks_elapsed, claimingGaugeRewardAmount);
     }
 
     /* ========== RESTRICTED FUNCTIONS - Owner or timelock only ========== */
@@ -310,11 +310,11 @@ contract FraxFamilialGaugeDistributor is Owned {
         );
     }
 
-    /// @notice Returns the `periodFinish` stored
-    /// @return periodFinish The periodFinish timestamp when gauges can call to distribute rewards
-    function periodFinish() external view returns (uint256) {
-        return periodFinish;
-    }
+    // /// @notice Returns the `periodFinish` stored
+    // /// @return periodFinish The periodFinish timestamp when gauges can call to distribute rewards
+    // function periodFinish() external view returns (uint256) {
+    //     return periodFinish;
+    // }
 
     /* ========== EVENTS ========== */
     event ChildGaugeAdded(address gauge, uint256 gauge_index);

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -30,8 +30,12 @@ import '../Uniswap/TransferHelper.sol';
 import "../Staking/Owned.sol";
 import "../Staking/IFraxFarm.sol";
 import "./IFraxGaugeControllerV2.sol";
+import "../ERC20/IERC20.sol";
+import "../ERC20/SafeERC20.sol";
 
 contract FraxFamilialGaugeDistributor is Owned {
+    using SafeERC20 for IERC20;
+    
     /* ========== STATE VARIABLES ========== */
     /// Note: variables made internal for execution gas savings, available through getters below
 

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -31,11 +31,8 @@ import "../Staking/Owned.sol";
 import "../Staking/IFraxFarm.sol";
 import "./IFraxGaugeControllerV2.sol";
 import "../ERC20/IERC20.sol";
-import "../ERC20/SafeERC20.sol";
 
 contract FraxFamilialGaugeDistributor is Owned {
-    using SafeERC20 for IERC20;
-    
     /* ========== STATE VARIABLES ========== */
     /// Note: variables made internal for execution gas savings, available through getters below
 
@@ -188,7 +185,7 @@ contract FraxFamilialGaugeDistributor is Owned {
 
             // call `sync_gauge_weights` on the other gauges
             for (uint256 i; i < gauges.length; i++) {
-                if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
+                if (gauges[i] != child_gauge && gauge_active[gauges[i]]) {
                     IFraxFarm(gauges[i]).sync_gauge_weights(true);
                 }
             }

--- a/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialGaugeDistributor.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.17;
+
+// ====================================================================
+// |     ______                   _______                             |
+// |    / _____________ __  __   / ____(_____  ____ _____  ________   |
+// |   / /_  / ___/ __ `| |/_/  / /_  / / __ \/ __ `/ __ \/ ___/ _ \  |
+// |  / __/ / /  / /_/ _>  <   / __/ / / / / / /_/ / / / / /__/  __/  |
+// | /_/   /_/   \__,_/_/|_|  /_/   /_/_/ /_/\__,_/_/ /_/\___/\___/   |
+// |                                                                  |
+// ====================================================================
+// ======================== FraxMiddlemanGauge ========================
+// ====================================================================
+/**
+*   @title FraxFamilialPitchGauge
+*   @notice Redistributes gauge rewards to multiple gauges (FraxFarms) based on each "child" gauge's `total_combined_weight`.
+*   @author Modified version of the FraxMiddlemanGauge - by ZrowGz @ Pitch Foundation
+*   @dev To use this:
+    *  - Set each Farm's gaugeController to address(0)
+    *  - Set each Farm's rewardsDistributor to this contract
+    *  - Set this as each Farm's reward token manager for FXS
+* Note: The farms will no longer communicate with the Frax gauge controller or the FXS rewards distributor
+*       Instead, after each reward period, the first interaction will call this contract during `sync()`
+*       This will then update the values from the controller & pull rewards in from distributor,
+*         sending the corrected amount to each child farm & writing the reward rate for FXS. 
+*/
+
+import "./IFraxGaugeFXSRewardsDistributor.sol";
+import '../Uniswap/TransferHelper.sol';
+import "../Staking/Owned.sol";
+import "../Staking/IFraxFarm.sol";
+import "./IFraxGaugeControllerV2.sol";
+
+contract FraxFamilialGaugeDistributor is Owned {//, ReentrancyGuard {
+    /* ========== STATE VARIABLES ========== */
+    /// Note: variables made internal for execution gas savings, available through getters below
+
+    // Informational
+    string public name;
+
+    ///// State Address Storage /////
+    /// @notice Address of the timelock
+    address internal timelock_address;
+    /// @notice Address of the gauge controller
+    address internal immutable gauge_controller;
+    /// @notice Address of the FXS Rewards Distributor
+    address internal immutable rewards_distributor;
+    /// @notice Address of the rewardToken
+    address internal immutable reward_token;// = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0; // FXS
+
+    ///// Familial Gauge Storage /////
+    /// @notice Array of all child gauges
+    address[] internal gauges;
+    /// @notice Whether a child gauge is active or not
+    mapping(address => bool) internal gauge_active;
+    /// @notice Global reward emission rate from Controller
+    uint256 internal global_emission_rate_stored;
+    /// @notice Time of the last vote from Controller
+    uint256 internal time_total_stored;
+
+    /// @notice Total vote weight from gauge controller vote
+    uint256 internal total_familial_relative_weight;
+    /// @notice Redistributed relative gauge weights by gauge combined weight
+    mapping(address => uint256) internal gauge_to_last_relative_weight;
+
+    /// @notice Sum of all child gauge `total_combined_weight`
+    uint256 internal familial_total_combined_weight;
+    /// @notice Each gauge's combined weight for this reward epoch, available at the farm
+    mapping(address => uint256) internal gauge_to_total_combined_weight;
+    
+    // Distributor provided 
+    /// @notice The timestamp of the vote period
+    uint256 public weeks_elapsed;
+    /// @notice The amount of FXS awarded to the family by the vote, from the Distributor
+    uint256 public reward_tally;
+    /// @notice The redistributed FXS rewards payable to each child gauge
+    mapping(address => uint256) internal gauge_to_reward_amount;
+
+    // Reward period & Time tracking
+    /// @notice The timestamp of the last reward period
+    uint256 internal periodFinish;
+    /// @notice The number of seconds in a week
+    uint256 internal constant rewardsDuration = 604800; // 7 * 86400  (7 days)
+
+    /* ========== MODIFIERS ========== */
+
+    modifier onlyByOwnGov() {
+        require(msg.sender == owner || msg.sender == timelock_address, "Not owner or timelock");
+        _;
+    }
+
+    /* ========== CONSTRUCTOR ========== */
+
+    constructor (
+        string calldata _name,
+        address _owner,
+        address _timelock_address,
+        address _rewards_distributor,
+        address _gauge_controller,
+        address _reward_token
+    ) Owned(_owner) {
+        timelock_address = _timelock_address;
+
+        rewards_distributor = _rewards_distributor;
+
+        name = _name;
+
+        gauge_controller = _gauge_controller;
+        reward_token = _reward_token;
+    }
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    /// This is called by the farm during `retroCatchUp`
+    /// If this is registered as a middleman gauge, distributor will call pullAndBridge, which will distribute the reward to the gauge
+    /// note it might be easier to NOT set this as a middleman on the distributor
+    /// Needs to be reentered to allow all farms to execute in one call, so is only callable by a gauge
+        /// This should only have the full recalculation logic ran once per epoch.
+    /// The first gauge to call this will trigger the full tvl & weight recalc
+    /// As other familial gauges call it, they'll be able to obtain the updated values from storage
+    /// The farm must call this through the `sync_gauge_weights` or `sync` functions
+    /// @notice Updates the relative weights of all child gauges
+    /// @dev Note: unfortunately many of the steps in this process need to be done after completing previous step for all children
+    //       - this results in numerous for loops being used
+
+    /// @notice Obtains the rewards, calculates each farm's FXS reward rate, update's the farm reward rate, & sends the FXS to the child
+    function distributeReward(address child_gauge) public returns (uint256, uint256) {
+        // check that the child gauge is active
+        require(gauge_active[child_gauge], "Gauge not active");
+        require(child_gauge == msg.sender, "caller!farm");
+
+        // the first call to this within the new rewards period should update everything & call all child farms
+        // the call to this is triggered by any interaction with the farm by a user, or by calling `sync`
+        if (block.timestamp > time_total_stored) {
+
+            ////////// FIRST - update the time period variables //////////
+
+            // store the most recent time_total for the farms to use & prevent this logic from being executed until epoch
+            time_total_stored = IFraxGaugeController(gauge_controller).time_total();//latest_time_total;
+
+            ////////// SECOND - get the reward rates and calculate them for the new period (from controller & distributor) //////////
+
+            // get & set the gauge controller's last global emission rate
+            global_emission_rate_stored = IFraxGaugeController(gauge_controller).global_emission_rate();//gauge_to_controller[gauges[i]]).global_emission_rate();
+
+            // get the familial vote weight for this period
+            total_familial_relative_weight = 
+                IFraxGaugeController(gauge_controller).gauge_relative_weight_write(address(this), timestamp);
+
+            // update all the gauge weights
+            for (uint256 i; i < gauges.length; i++) {
+                // it shouldn't be zero, unless we don't use `delete` to remove a gauge
+                if (gauge_active[gauges[i]]) { 
+                    /// update the child gauges' total combined weights
+                    gauge_to_total_combined_weight[gauges[i]] = IFraxFarm(gauges[i]).totalCombinedWeight();
+                    familial_total_combined_weight += gauge_to_total_combined_weight[gauges[i]];
+                }
+            }
+
+            // divvy up the relative weights based on each gauges `total combined weight` 
+            for (uint256 i; i < gauges.length; i++) {
+                if (gauge_active[gauges[i]]) { 
+                    gauge_to_last_relative_weight[gauges[i]] = 
+                        gauge_to_total_combined_weight[gauges[i]] * total_familial_relative_weight / familial_total_combined_weight;
+                }
+            }
+
+            // pull in the reward tokens allocated to the fam
+            (weeks_elapsed, reward_tally) = IFraxGaugeFXSRewardsDistributor(rewards_distributor).distributeReward(address(this));
+            emit FamilialRewardClaimed(address(this), weeks_elapsed, reward_tally);
+
+            // divide the reward_tally amount by the gauge's allocation to get the allocation
+            for (uint256 i; i < gauges.length; i++) {
+                if (gauge_active[gauges[i]]) { 
+                    // gauge reward token allocation = family reward amount * gauge's total combined weight / familial total combined weight
+                    // note this is NOT the reward rate to write to the farm, just the redistributed amount
+                    gauge_to_reward_amount[gauges[i]] = reward_tally * gauge_to_total_combined_weight[gauges[i]] / familial_total_combined_weight;
+                }
+            }
+
+            // call `sync_gauge_weights` on the other gauges
+            for (uint256 i; i < gauges.length; i++) {
+                if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
+                    IFraxFarm(gauges[i]).sync_gauge_weights(true);
+                }
+            }
+
+            ////////// THIRD - trigger all child gauges to call this contract //////////
+
+            // now that this logic won't be ran on the next call & all gauges are updated, call each farm's `sync`
+            // during the first call to this contract, it will call all other child farms, but not itsself again
+            for (uint256 i; i < gauges.length; i++) {
+                // if the iteration is not the initial calling gauge & the gauge is active, call `sync`
+                if (gauges[i] != child_gauge && gauge_active[gauges[i]]) {
+                    IFraxFarm(gauges[i]).sync();
+                }
+            }
+
+            ////////// FINALLY - all other farms are updated, let the calling farm finish execution //////////
+        }
+
+        // preserve the gauge's reward tally for returning to the gauge
+        uint256 claimingGaugeRewardAmount = gauge_to_reward_amount[child_gauge];
+        
+        /// when the reward is distributed, send the amount in gauge_to_reward_amount to the gauge & zero that value out
+        TransferHelper.safeTransfer(reward_token, child_gauge, claimingGaugeRewardAmount);
+        
+        // Update the child farm reward vars: reward token, the reward rate/tally, zero address for gauge controller, this address as distributor
+        IFraxFarm(child_gauge).setRewardRates(rewardToken, (claimingGaugeRewardAmount / rewardsDuration), address(0), address(this));
+        
+        // reset the reward tally to zero for the gauge
+        gauge_to_reward_amount[child_gauge] = 0;
+        emit ChildGaugeRewardDistributed(child_gauge, claimingGaugeRewardAmount);
+
+        // the farm doesn't actually write this anywhere
+        return (weeks_elapsed, claimingGaugeRewardRate);
+    }
+
+    /* ========== RESTRICTED FUNCTIONS - Owner or timelock only ========== */
+    
+    // Added to support recovering LP Rewards and other mistaken tokens from other systems to be distributed to holders
+    function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyByOwnGov {
+        // Only the owner address can ever receive the recovery withdrawal
+        TransferHelper.safeTransfer(tokenAddress, owner, tokenAmount);
+        emit RecoveredERC20(tokenAddress, tokenAmount);
+    }
+
+    // Generic proxy
+    function execute(
+        address _to,
+        uint256 _value,
+        bytes calldata _data
+    ) external onlyByOwnGov returns (bool, bytes memory) {
+        (bool success, bytes memory result) = _to.call{value:_value}(_data);
+        return (success, result);
+    }
+
+    function setTimelock(address _new_timelock) external onlyByOwnGov {
+        timelock_address = _new_timelock;
+    }
+
+    function addChildren(address[] calldata _gauges) external onlyByOwnGov {
+        // set the latest period finish for the child gauges
+        for (uint256 i; i < _gauges.length; i++) {
+            // set gauge to active
+            gauge_active[_gauges[i]] = true;
+            emit ChildGaugeAdded(_gauges[i], _gauges.length - 1);
+        }
+    }
+
+    function deactivateChildGauge(uint256 _gaugeIndex) external onlyByOwnGov {
+        emit ChildGaugeDeactivated(gauges[_gaugeIndex], _gaugeIndex);
+        gauge_active[gauges[_gaugeIndex]] = false;
+    }
+
+    // function setRewardsDistributor(address _rewards_distributor) external onlyByOwnGov {
+    //     emit RewardsDistributorChanged(rewards_distributor, _rewards_distributor);
+    //     rewards_distributor = _rewards_distributor;
+    // }
+
+    // function setGaugeController(address _gauge_controller) external onlyByOwnGov {
+    //     emit GaugeControllerChanged(gauge_controller, _gauge_controller);
+    //     gauge_controller = _gauge_controller;
+    // }
+
+    /* ========== GETTERS ========== */
+
+    /// @notice Matches the abi available in the farms 
+    /// @return global_emission_rate The global emission rate from the controller
+    function global_emission_rate() external view returns (uint256) {
+        return global_emission_rate_stored;
+    }
+
+    /// @notice Matches the abi available in the farms
+    /// @return time_total The end of the vote period from the controller
+    function time_total() external view returns (uint256) {
+        return time_total_stored;
+    }
+
+    
+    function getNumberOfGauges() external view returns (uint256) {
+        return gauges.length;
+    }
+
+    function getChildGauges() external view returns (address[] memory) {
+        return gauges;
+    }
+
+    function getGaugeState(address _gauge) external view returns (bool) {
+        return gauge_active[_gauge];
+    }
+
+    function getStateAddresses() external view returns (address, address, address, address) {
+        return (timelock_address, gauge_controller, rewards_distributor, reward_token);
+    }
+
+    /// @notice Returns the last relative weight and reward tally for a gauge
+    /// @return last_relative_weight The redistributed last relative weight of the gauge
+    /// @return reward_tally The redistributed reward rate of the gauge
+    function getChildGaugeValues(address child_gauge) external view returns (uint256, uint256) {
+        return (
+            gauge_to_last_relative_weight[child_gauge],
+            gauge_to_reward_amount[child_gauge]
+        );
+    }
+
+    /// @notice Returns the `periodFinish` stored
+    /// @return periodFinish The periodFinish timestamp when gauges can call to distribute rewards
+    function periodFinish() external view returns (uint256) {
+        return periodFinish;
+    }
+
+    /* ========== EVENTS ========== */
+    event ChildGaugeAdded(address gauge, uint256 gauge_index);
+    event ChildGaugeDeactivated(address gauge, uint256 gauge_index);
+    event GaugeControllerChanged(address old_controller, address new_controller);
+    event RewardsDistributorChanged(address old_distributor, address new_distributor);
+    event FamilialRewardClaimed(address familial_gauge, uint256 reward_amount, uint256 weeks_elapsed);
+    event RecoveredERC20(address token, uint256 amount);
+
+    event ChildGaugeRewardDistributed(address gauge, uint256 rewardAmount);
+}

--- a/src/hardhat/contracts/Curve/FraxFamilialPitchGauge.sol
+++ b/src/hardhat/contracts/Curve/FraxFamilialPitchGauge.sol
@@ -46,344 +46,344 @@ import "./IFraxGaugeControllerV2.sol";
 *       - Disable rewards for pre-existing gauges on the FXS Rewards Distributor
 */
 
-contract FraxFamilialPitchGauge is Owned {//, ReentrancyGuard {
-    // using SafeMath for uint256;
-    // using SafeERC20 for ERC20;
+// contract FraxFamilialPitchGauge is Owned {//, ReentrancyGuard {
+//     // using SafeMath for uint256;
+//     // using SafeERC20 for ERC20;
 
-    // error LatestPeriodNotFinished(uint256,uint256);
+//     // error LatestPeriodNotFinished(uint256,uint256);
 
-    /* ========== STATE VARIABLES ========== */
-    /// Note: variables made internal for execution gas savings, available through getters below
+//     /* ========== STATE VARIABLES ========== */
+//     /// Note: variables made internal for execution gas savings, available through getters below
 
-    // Informational
-    string public name;
+//     // Informational
+//     string public name;
 
-    ///// State Address Storage /////
-    /// @notice Address of the timelock
-    address internal timelock_address;
-    /// @notice Address of the gauge controller
-    address internal immutable gauge_controller;
-    /// @notice Address of the FXS Rewards Distributor
-    address internal immutable rewards_distributor;
-    /// @notice Address of the rewardToken
-    address internal immutable reward_token;// = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0; // FXS
+//     ///// State Address Storage /////
+//     /// @notice Address of the timelock
+//     address internal timelock_address;
+//     /// @notice Address of the gauge controller
+//     address internal immutable gauge_controller;
+//     /// @notice Address of the FXS Rewards Distributor
+//     address internal immutable rewards_distributor;
+//     /// @notice Address of the rewardToken
+//     address internal immutable reward_token;// = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0; // FXS
 
-    ///// Familial Gauge Storage /////
-    /// @notice Array of all child gauges
-    address[] internal gauges;
-    /// @notice Whether a child gauge is active or not
-    mapping(address => bool) internal gauge_active;
-    /// @notice Global reward emission rate from Controller
-    uint256 internal global_emission_rate_stored;
-    /// @notice Time of the last vote from Controller
-    uint256 internal time_total_stored;
+//     ///// Familial Gauge Storage /////
+//     /// @notice Array of all child gauges
+//     address[] internal gauges;
+//     /// @notice Whether a child gauge is active or not
+//     mapping(address => bool) internal gauge_active;
+//     /// @notice Global reward emission rate from Controller
+//     uint256 internal global_emission_rate_stored;
+//     /// @notice Time of the last vote from Controller
+//     uint256 internal time_total_stored;
 
-    /// @notice Total vote weight from gauge controller vote
-    uint256 internal total_familial_relative_weight;
-    /// @notice Redistributed relative gauge weights by gauge combined weight
-    mapping(address => uint256) internal gauge_to_last_relative_weight;
+//     /// @notice Total vote weight from gauge controller vote
+//     uint256 internal total_familial_relative_weight;
+//     /// @notice Redistributed relative gauge weights by gauge combined weight
+//     mapping(address => uint256) internal gauge_to_last_relative_weight;
 
-    /// @notice Sum of all child gauge `total_combined_weight`
-    uint256 internal familial_total_combined_weight;
-    /// @notice Each gauge's combined weight for this reward epoch, available at the farm
-    mapping(address => uint256) internal gauge_to_total_combined_weight;
+//     /// @notice Sum of all child gauge `total_combined_weight`
+//     uint256 internal familial_total_combined_weight;
+//     /// @notice Each gauge's combined weight for this reward epoch, available at the farm
+//     mapping(address => uint256) internal gauge_to_total_combined_weight;
     
-    // Distributor provided 
-    /// @notice The timestamp of the vote period
-    uint256 public weeks_elapsed;
-    /// @notice The amount of FXS awarded to the family by the vote, from the Distributor
-    uint256 public reward_tally;
-    /// @notice The redistributed FXS rewards payable to each child gauge
-    mapping(address => uint256) internal gauge_to_reward_tally;
+//     // Distributor provided 
+//     /// @notice The timestamp of the vote period
+//     uint256 public weeks_elapsed;
+//     /// @notice The amount of FXS awarded to the family by the vote, from the Distributor
+//     uint256 public reward_tally;
+//     /// @notice The redistributed FXS rewards payable to each child gauge
+//     mapping(address => uint256) internal gauge_to_reward_tally;
 
-    // Reward period & Time tracking
-    /// @notice The timestamp of the last reward period
-    uint256 internal periodFinish;
-    /// @notice The number of seconds in a week
-    uint256 internal constant rewardsDuration = 604800; // 7 * 86400  (7 days)
-    /// @notice For the first time children are added, pull in the reward period finish for each.
-    bool internal isFirstTimeAddingGauges;
+//     // Reward period & Time tracking
+//     /// @notice The timestamp of the last reward period
+//     uint256 internal periodFinish;
+//     /// @notice The number of seconds in a week
+//     uint256 internal constant rewardsDuration = 604800; // 7 * 86400  (7 days)
+//     /// @notice For the first time children are added, pull in the reward period finish for each.
+//     bool internal isFirstTimeAddingGauges;
 
-    /* ========== MODIFIERS ========== */
+//     /* ========== MODIFIERS ========== */
 
-    modifier onlyByOwnGov() {
-        require(msg.sender == owner || msg.sender == timelock_address, "Not owner or timelock");
-        _;
-    }
+//     modifier onlyByOwnGov() {
+//         require(msg.sender == owner || msg.sender == timelock_address, "Not owner or timelock");
+//         _;
+//     }
 
-    /* ========== CONSTRUCTOR ========== */
+//     /* ========== CONSTRUCTOR ========== */
 
-    constructor (
-        string memory _name,
-        address _owner,
-        address _timelock_address,
-        address _rewards_distributor,
-        address _gauge_controller,
-        address _reward_token
-    ) Owned(_owner) {
-        timelock_address = _timelock_address;
+//     constructor (
+//         string memory _name,
+//         address _owner,
+//         address _timelock_address,
+//         address _rewards_distributor,
+//         address _gauge_controller,
+//         address _reward_token
+//     ) Owned(_owner) {
+//         timelock_address = _timelock_address;
 
-        rewards_distributor = _rewards_distributor;
+//         rewards_distributor = _rewards_distributor;
 
-        name = _name;
+//         name = _name;
 
-        gauge_controller = _gauge_controller;
-        reward_token = _reward_token;
-    }
+//         gauge_controller = _gauge_controller;
+//         reward_token = _reward_token;
+//     }
 
-    /* ========== MUTATIVE FUNCTIONS ========== */
+//     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    /// This should only have the full recalculation logic ran once per epoch.
-    /// The first gauge to call this will trigger the full tvl & weight recalc
-    /// As other familial gauges call it, they'll be able to obtain the updated values from storage
-    /// The farm must call this through the `sync_gauge_weights` or `sync` functions
-    /// @notice Updates the relative weights of all child gauges
-    /// @dev Note: unfortunately many of the steps in this process need to be done after completing previous step for all children
-    //       - this results in numerous for loops being used
-    function gauge_relative_weight_write(address child_gauge, uint256 timestamp) external returns (uint256) {
-        // check that the child gauge is active
-        require(gauge_active[child_gauge], "Gauge not active");
+//     /// This should only have the full recalculation logic ran once per epoch.
+//     /// The first gauge to call this will trigger the full tvl & weight recalc
+//     /// As other familial gauges call it, they'll be able to obtain the updated values from storage
+//     /// The farm must call this through the `sync_gauge_weights` or `sync` functions
+//     /// @notice Updates the relative weights of all child gauges
+//     /// @dev Note: unfortunately many of the steps in this process need to be done after completing previous step for all children
+//     //       - this results in numerous for loops being used
+//     function gauge_relative_weight_write(address child_gauge, uint256 timestamp) external returns (uint256) {
+//         // check that the child gauge is active
+//         require(gauge_active[child_gauge], "Gauge not active");
 
-        // If now is after the last time everything was updated, obtain all values for all gauges & recalculate new rebalanced weights
-        if (block.timestamp > time_total_stored) {
-            //// First, update all the state variables applicable to all child gauges
-            // store the most recent time_total for the farms to use & prevent this logic from being executed until epoch
-            time_total_stored = IFraxGaugeController(gauge_controller).time_total();//latest_time_total;
+//         // If now is after the last time everything was updated, obtain all values for all gauges & recalculate new rebalanced weights
+//         if (block.timestamp > time_total_stored) {
+//             //// First, update all the state variables applicable to all child gauges
+//             // store the most recent time_total for the farms to use & prevent this logic from being executed until epoch
+//             time_total_stored = IFraxGaugeController(gauge_controller).time_total();//latest_time_total;
 
-            // get & set the gauge controller's last global emission rate
-            // note this should be the same for all gauges, but if there were to be multiple controllers,
-            // we would need to have the emission rate for each of them.
-            global_emission_rate_stored = IFraxGaugeController(gauge_controller).global_emission_rate();//gauge_to_controller[gauges[i]]).global_emission_rate();
+//             // get & set the gauge controller's last global emission rate
+//             // note this should be the same for all gauges, but if there were to be multiple controllers,
+//             // we would need to have the emission rate for each of them.
+//             global_emission_rate_stored = IFraxGaugeController(gauge_controller).global_emission_rate();//gauge_to_controller[gauges[i]]).global_emission_rate();
 
-            // to prevent re-calling the first gauge
-            address _gauge_calling;
-            for (uint256 i; i < gauges.length; i++) {
-                if (child_gauge == gauges[i]) {
-                    _gauge_calling = gauges[i];
-                }
-            }
+//             // to prevent re-calling the first gauge
+//             address _gauge_calling;
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (child_gauge == gauges[i]) {
+//                     _gauge_calling = gauges[i];
+//                 }
+//             }
 
-            /// NOTE requiring caller to be `msg.sender` ensures all gauges are distributed to.
-            ///      To access this function, must call `sync_gauge_weights` on the gauge, which will call this
-            // require it to be one of the child gauges to ensure correctly updating all children
-            require(_gauge_calling == child_gauge && child_gauge == msg.sender, "Not a child gauge");
+//             /// NOTE requiring caller to be `msg.sender` ensures all gauges are distributed to.
+//             ///      To access this function, must call `sync_gauge_weights` on the gauge, which will call this
+//             // require it to be one of the child gauges to ensure correctly updating all children
+//             require(_gauge_calling == child_gauge && child_gauge == msg.sender, "Not a child gauge");
 
-            // zero out the stored familial combined weight
-            familial_total_combined_weight = 0;
+//             // zero out the stored familial combined weight
+//             // familial_total_combined_weight = 0;  /// todo resets it in the next step
 
-            // get the familial vote weight for this period
-            total_familial_relative_weight = 
-                IFraxGaugeController(gauge_controller).gauge_relative_weight_write(address(this), timestamp);
+//             // get the familial vote weight for this period
+//             total_familial_relative_weight = 
+//                 IFraxGaugeController(gauge_controller).gauge_relative_weight_write(address(this), timestamp);
 
-            // update all the gauge weights
-            for (uint256 i; i < gauges.length; i++) {
-                // it shouldn't be zero, unless we don't use `delete` to remove a gauge
-                if (gauge_active[gauges[i]]) { 
-                    /// update the child gauges' total combined weights
-                    gauge_to_total_combined_weight[gauges[i]] = IFraxFarm(gauges[i]).totalCombinedWeight();
-                    familial_total_combined_weight += gauge_to_total_combined_weight[gauges[i]];
-                }
-            }
+//             // update all the gauge weights
+//             for (uint256 i; i < gauges.length; i++) {
+//                 // it shouldn't be zero, unless we don't use `delete` to remove a gauge
+//                 if (gauge_active[gauges[i]]) { 
+//                     /// update the child gauges' total combined weights
+//                     gauge_to_total_combined_weight[gauges[i]] = IFraxFarm(gauges[i]).totalCombinedWeight();
+//                     familial_total_combined_weight += gauge_to_total_combined_weight[gauges[i]];
+//                 }
+//             }
 
-            // divvy up the relative weights based on each gauges `total combined weight` 
-            for (uint256 i; i < gauges.length; i++) {
-                if (gauge_active[gauges[i]]) { 
-                    gauge_to_last_relative_weight[gauges[i]] = 
-                        gauge_to_total_combined_weight[gauges[i]] * total_familial_relative_weight / familial_total_combined_weight;
-                }
-            }
+//             // divvy up the relative weights based on each gauges `total combined weight` 
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (gauge_active[gauges[i]]) { 
+//                     gauge_to_last_relative_weight[gauges[i]] = 
+//                         gauge_to_total_combined_weight[gauges[i]] * total_familial_relative_weight / familial_total_combined_weight;
+//                 }
+//             }
 
-            // pull in the reward tokens allocated to the fam
-            (weeks_elapsed, reward_tally) = IFraxGaugeFXSRewardsDistributor(rewards_distributor).distributeReward(address(this));
-            emit FamilialRewardClaimed(address(this), weeks_elapsed, reward_tally);
+//             // pull in the reward tokens allocated to the fam
+//             (weeks_elapsed, reward_tally) = IFraxGaugeFXSRewardsDistributor(rewards_distributor).distributeReward(address(this));
+//             emit FamilialRewardClaimed(address(this), weeks_elapsed, reward_tally);
 
-            // divide the reward_tally amount by the gauge's allocation
-            // note this will be used when the farm calls `distributeReward`
-            for (uint256 i; i < gauges.length; i++) {
-                if (gauge_active[gauges[i]]) { 
-                    gauge_to_reward_tally[gauges[i]] = reward_tally * gauge_to_total_combined_weight[gauges[i]] / familial_total_combined_weight;
-                }
-            }
+//             // divide the reward_tally amount by the gauge's allocation
+//             // note this will be used when the farm calls `distributeReward`
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (gauge_active[gauges[i]]) { 
+//                     gauge_to_reward_tally[gauges[i]] = reward_tally * gauge_to_total_combined_weight[gauges[i]] / familial_total_combined_weight / rewardsDuration;
+//                 }
+//             }
 
-            // call `sync_gauge_weights` on the other gauges
-            for (uint256 i; i < gauges.length; i++) {
-                if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
-                    IFraxFarm(gauges[i]).sync_gauge_weights(true);
-                }
-            }
-            /// Now all farms should have their relative weights updated. Let the calling farm finish execution
-        }
+//             // call `sync_gauge_weights` on the other gauges
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
+//                     IFraxFarm(gauges[i]).sync_gauge_weights(true);
+//                 }
+//             }
+//             /// Now all farms should have their relative weights updated. Let the calling farm finish execution
+//         }
 
-        // finally, return the gauge's (msg.sender) rebalanced relative weight
-        return gauge_to_last_relative_weight[child_gauge];
-    }
+//         // finally, return the gauge's (msg.sender) rebalanced relative weight
+//         return gauge_to_last_relative_weight[child_gauge];
+//     }
 
-    /// This is called by the farm during `retroCatchUp`
-    /// If this is registered as a middleman gauge, distributor will call pullAndBridge, which will distribute the reward to the gauge
-    /// note it might be easier to NOT set this as a middleman on the distributor
-    /// Needs to be reentered to allow all farms to execute in one call, so is only callable by a gauge
-    function distributeReward(address child_gauge) public returns (uint256, uint256) {
-        // check that the child gauge is active
-        require(gauge_active[child_gauge], "Gauge not active");
+//     /// This is called by the farm during `retroCatchUp`
+//     /// If this is registered as a middleman gauge, distributor will call pullAndBridge, which will distribute the reward to the gauge
+//     /// note it might be easier to NOT set this as a middleman on the distributor
+//     /// Needs to be reentered to allow all farms to execute in one call, so is only callable by a gauge
+//     function distributeReward(address child_gauge) public returns (uint256, uint256) {
+//         // check that the child gauge is active
+//         require(gauge_active[child_gauge], "Gauge not active");
 
-        if (block.timestamp >= periodFinish) {
-            // Ensure the provided reward amount is not more than the balance in the contract.
-            // This keeps the reward rate in the right range, preventing overflows due to
-            // very high values of rewardRate in the earned and rewardsPerToken functions;
-            // Reward + leftover must be less than 2^256 / 10^18 to avoid overflow.
-            uint256 num_periods_elapsed = uint256(block.timestamp - periodFinish) / rewardsDuration; // Floor division to the nearest period
+//         if (block.timestamp >= periodFinish) {
+//             // Ensure the provided reward amount is not more than the balance in the contract.
+//             // This keeps the reward rate in the right range, preventing overflows due to
+//             // very high values of rewardRate in the earned and rewardsPerToken functions;
+//             // Reward + leftover must be less than 2^256 / 10^18 to avoid overflow.
+//             uint256 num_periods_elapsed = uint256(block.timestamp - periodFinish) / rewardsDuration; // Floor division to the nearest period
 
-            // lastUpdateTime = periodFinish;
-            // update period finish here so that the next call to `distributeReward` will bypapss this logic
-            periodFinish = periodFinish + ((num_periods_elapsed + 1) * rewardsDuration);
+//             // lastUpdateTime = periodFinish;
+//             // update period finish here so that the next call to `distributeReward` will bypapss this logic
+//             periodFinish = periodFinish + ((num_periods_elapsed + 1) * rewardsDuration);
 
-            // to prevent re-calling the first gauge during the farm `sync` calls
-            address _gauge_calling;
-            for (uint256 i; i < gauges.length; i++) {
-                if (child_gauge == gauges[i]) {
-                    _gauge_calling = gauges[i];
-                }
-            }
+//             // to prevent re-calling the first gauge during the farm `sync` calls
+//             address _gauge_calling;
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (child_gauge == gauges[i]) {
+//                     _gauge_calling = gauges[i];
+//                 }
+//             }
 
-            /// NOTE requiring caller to be `msg.sender` ensures all gauges are distributed to.
-            ///      To access this function, must call `sync` on the gauge, which will call this
-            // require it to be one of the child gauges to ensure correctly updating all children
-            require(_gauge_calling == child_gauge && child_gauge == msg.sender, "Not a child gauge");
+//             /// NOTE requiring caller to be `msg.sender` ensures all gauges are distributed to.
+//             ///      To access this function, must call `sync` on the gauge, which will call this
+//             // require it to be one of the child gauges to ensure correctly updating all children
+//             require(_gauge_calling == child_gauge && child_gauge == msg.sender, "Not a child gauge");
 
-            // now that this logic won't be ran on the next call & all gauges are within periodFinish, call each farm's `sync`
-            for (uint256 i; i < gauges.length; i++) {
-                if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
-                    IFraxFarm(gauges[i]).sync();
-                }
-            }
-            /// Now all gauges should have their rewards distributed. Let the calling gauge finish execution.
-        }
+//             // now that this logic won't be ran on the next call & all gauges are within periodFinish, call each farm's `sync`
+//             for (uint256 i; i < gauges.length; i++) {
+//                 if (gauges[i] != _gauge_calling && gauge_active[gauges[i]]) {
+//                     IFraxFarm(gauges[i]).sync();
+//                 }
+//             }
+//             /// Now all gauges should have their rewards distributed. Let the calling gauge finish execution.
+//         }
 
-        // preserve the gauge's reward tally for returning to the gauge
-        uint256 claimingGaugeRewardTally = gauge_to_reward_tally[child_gauge];
+//         // preserve the gauge's reward tally for returning to the gauge
+//         uint256 claimingGaugeRewardTally = gauge_to_reward_tally[child_gauge];
         
-        /// when the reward is distributed, send the amount in gauge_to_reward_tally to the gauge & zero that value out
-        TransferHelper.safeTransfer(reward_token, child_gauge, claimingGaugeRewardTally);
+//         /// when the reward is distributed, send the amount in gauge_to_reward_tally to the gauge & zero that value out
+//         TransferHelper.safeTransfer(reward_token, child_gauge, claimingGaugeRewardTally);
         
-        // reset the reward tally to zero for the gauge
-        gauge_to_reward_tally[child_gauge] = 0;
-        emit ChildGaugeRewardDistributed(child_gauge, gauge_to_reward_tally[child_gauge]);
+//         // reset the reward tally to zero for the gauge
+//         gauge_to_reward_tally[child_gauge] = 0;
+//         emit ChildGaugeRewardDistributed(child_gauge, gauge_to_reward_tally[child_gauge]);
         
-        return (weeks_elapsed, claimingGaugeRewardTally);
-    }
+//         return (weeks_elapsed, claimingGaugeRewardTally);
+//     }
 
-    /* ========== RESTRICTED FUNCTIONS - Owner or timelock only ========== */
+//     /* ========== RESTRICTED FUNCTIONS - Owner or timelock only ========== */
     
-    // Added to support recovering LP Rewards and other mistaken tokens from other systems to be distributed to holders
-    function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyByOwnGov {
-        // Only the owner address can ever receive the recovery withdrawal
-        TransferHelper.safeTransfer(tokenAddress, owner, tokenAmount);
-        emit RecoveredERC20(tokenAddress, tokenAmount);
-    }
+//     // Added to support recovering LP Rewards and other mistaken tokens from other systems to be distributed to holders
+//     function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyByOwnGov {
+//         // Only the owner address can ever receive the recovery withdrawal
+//         TransferHelper.safeTransfer(tokenAddress, owner, tokenAmount);
+//         emit RecoveredERC20(tokenAddress, tokenAmount);
+//     }
 
-    // Generic proxy
-    function execute(
-        address _to,
-        uint256 _value,
-        bytes calldata _data
-    ) external onlyByOwnGov returns (bool, bytes memory) {
-        (bool success, bytes memory result) = _to.call{value:_value}(_data);
-        return (success, result);
-    }
+//     // Generic proxy
+//     function execute(
+//         address _to,
+//         uint256 _value,
+//         bytes calldata _data
+//     ) external onlyByOwnGov returns (bool, bytes memory) {
+//         (bool success, bytes memory result) = _to.call{value:_value}(_data);
+//         return (success, result);
+//     }
 
-    function setTimelock(address _new_timelock) external onlyByOwnGov {
-        timelock_address = _new_timelock;
-    }
+//     function setTimelock(address _new_timelock) external onlyByOwnGov {
+//         timelock_address = _new_timelock;
+//     }
 
-    function addChildGauge(address[] calldata _gauges) external onlyByOwnGov {
-        gauges = _gauges;
-        // set the latest period finish for the child gauges
-        for (uint256 i; i < gauges.length; i++) {
-            // set gauge to active
-            gauge_active[_gauges[i]] = true;
+//     function addChildGauge(address[] calldata _gauges) external onlyByOwnGov {
+//         gauges = _gauges;
+//         // set the latest period finish for the child gauges
+//         for (uint256 i; i < gauges.length; i++) {
+//             // set gauge to active
+//             gauge_active[_gauges[i]] = true;
 
-            emit ChildGaugeAdded(_gauges[i], gauges.length - 1);
+//             emit ChildGaugeAdded(_gauges[i], gauges.length - 1);
 
-            if (isFirstTimeAddingGauges) {
-                uint256 childGaugePeriodFinish = IFraxFarm(gauges[i]).periodFinish();
-                if (childGaugePeriodFinish > periodFinish) {
-                    periodFinish = childGaugePeriodFinish;
-                }
-            }
-        }
-        // don't need to re-run that lookup to sync in the future
-        if (isFirstTimeAddingGauges) {
-            isFirstTimeAddingGauges = false;
-        }
-    }
+//             if (isFirstTimeAddingGauges) {
+//                 uint256 childGaugePeriodFinish = IFraxFarm(gauges[i]).periodFinish();
+//                 if (childGaugePeriodFinish > periodFinish) {
+//                     periodFinish = childGaugePeriodFinish;
+//                 }
+//             }
+//         }
+//         // don't need to re-run that lookup to sync in the future
+//         if (isFirstTimeAddingGauges) {
+//             isFirstTimeAddingGauges = false;
+//         }
+//     }
 
-    function deactivateChildGauge(uint256 _gaugeIndex) external onlyByOwnGov {
-        emit ChildGaugeDeactivated(gauges[_gaugeIndex], _gaugeIndex);
-        gauge_active[gauges[_gaugeIndex]] = false;
-    }
+//     function deactivateChildGauge(uint256 _gaugeIndex) external onlyByOwnGov {
+//         emit ChildGaugeDeactivated(gauges[_gaugeIndex], _gaugeIndex);
+//         gauge_active[gauges[_gaugeIndex]] = false;
+//     }
 
-    // function setRewardsDistributor(address _rewards_distributor) external onlyByOwnGov {
-    //     emit RewardsDistributorChanged(rewards_distributor, _rewards_distributor);
-    //     rewards_distributor = _rewards_distributor;
-    // }
+//     // function setRewardsDistributor(address _rewards_distributor) external onlyByOwnGov {
+//     //     emit RewardsDistributorChanged(rewards_distributor, _rewards_distributor);
+//     //     rewards_distributor = _rewards_distributor;
+//     // }
 
-    // function setGaugeController(address _gauge_controller) external onlyByOwnGov {
-    //     emit GaugeControllerChanged(gauge_controller, _gauge_controller);
-    //     gauge_controller = _gauge_controller;
-    // }
-    /* ========== GETTERS ========== */
+//     // function setGaugeController(address _gauge_controller) external onlyByOwnGov {
+//     //     emit GaugeControllerChanged(gauge_controller, _gauge_controller);
+//     //     gauge_controller = _gauge_controller;
+//     // }
+//     /* ========== GETTERS ========== */
 
-    /// @notice Matches the abi available in the farms 
-    /// @return global_emission_rate The global emission rate from the controller
-    function global_emission_rate() external view returns (uint256) {
-        return global_emission_rate_stored;
-    }
+//     /// @notice Matches the abi available in the farms 
+//     /// @return global_emission_rate The global emission rate from the controller
+//     function global_emission_rate() external view returns (uint256) {
+//         return global_emission_rate_stored;
+//     }
 
-    /// @notice Matches the abi available in the farms
-    /// @return time_total The end of the vote period from the controller
-    function time_total() external view returns (uint256) {
-        return time_total_stored;
-    }
+//     /// @notice Matches the abi available in the farms
+//     /// @return time_total The end of the vote period from the controller
+//     function time_total() external view returns (uint256) {
+//         return time_total_stored;
+//     }
 
     
-    function getNumberOfGauges() external view returns (uint256) {
-        return gauges.length;
-    }
+//     function getNumberOfGauges() external view returns (uint256) {
+//         return gauges.length;
+//     }
 
-    function getChildGauges() external view returns (address[] memory) {
-        return gauges;
-    }
+//     function getChildGauges() external view returns (address[] memory) {
+//         return gauges;
+//     }
 
-    function getGaugeState(address _gauge) external view returns (bool) {
-        return gauge_active[_gauge];
-    }
+//     function getGaugeState(address _gauge) external view returns (bool) {
+//         return gauge_active[_gauge];
+//     }
 
-    function getStateAddresses() external view returns (address, address, address, address) {
-        return (timelock_address, gauge_controller, rewards_distributor, reward_token);
-    }
+//     function getStateAddresses() external view returns (address, address, address, address) {
+//         return (timelock_address, gauge_controller, rewards_distributor, reward_token);
+//     }
 
-    /// @notice Returns the last relative weight and reward tally for a gauge
-    /// @return last_relative_weight The redistributed last relative weight of the gauge
-    /// @return reward_tally The redistributed reward tally of the gauge
-    function getChildGaugeValues(address child_gauge) external view returns (uint256, uint256) {
-        return (
-            gauge_to_last_relative_weight[child_gauge],
-            gauge_to_reward_tally[child_gauge]
-        );
-    }
+//     /// @notice Returns the last relative weight and reward tally for a gauge
+//     /// @return last_relative_weight The redistributed last relative weight of the gauge
+//     /// @return reward_tally The redistributed reward tally of the gauge
+//     function getChildGaugeValues(address child_gauge) external view returns (uint256, uint256) {
+//         return (
+//             gauge_to_last_relative_weight[child_gauge],
+//             gauge_to_reward_tally[child_gauge]
+//         );
+//     }
 
-    /// @notice Returns the `periodFinish` stored
-    /// @return periodFinish The periodFinish timestamp when gauges can call to distribute rewards
-    function getPeriodFinish() external view returns (uint256) {
-        return periodFinish;
-    }
+//     /// @notice Returns the `periodFinish` stored
+//     /// @return periodFinish The periodFinish timestamp when gauges can call to distribute rewards
+//     function getPeriodFinish() external view returns (uint256) {
+//         return periodFinish;
+//     }
 
-    /* ========== EVENTS ========== */
-    event ChildGaugeAdded(address gauge, uint256 gauge_index);
-    event ChildGaugeDeactivated(address gauge, uint256 gauge_index);
-    event GaugeControllerChanged(address old_controller, address new_controller);
-    event RewardsDistributorChanged(address old_distributor, address new_distributor);
-    event FamilialRewardClaimed(address familial_gauge, uint256 reward_amount, uint256 weeks_elapsed);
-    event ChildGaugeRewardDistributed(address gauge, uint256 reward_amount);
-    event RecoveredERC20(address token, uint256 amount);
-}
+//     /* ========== EVENTS ========== */
+//     event ChildGaugeAdded(address gauge, uint256 gauge_index);
+//     event ChildGaugeDeactivated(address gauge, uint256 gauge_index);
+//     event GaugeControllerChanged(address old_controller, address new_controller);
+//     event RewardsDistributorChanged(address old_distributor, address new_distributor);
+//     event FamilialRewardClaimed(address familial_gauge, uint256 reward_amount, uint256 weeks_elapsed);
+//     event ChildGaugeRewardDistributed(address gauge, uint256 reward_amount);
+//     event RecoveredERC20(address token, uint256 amount);
+// }

--- a/src/hardhat/contracts/Curve/FraxGaugeControllerV2.sol
+++ b/src/hardhat/contracts/Curve/FraxGaugeControllerV2.sol
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+// import "lib/forge-std/src/console2.sol";
+
+/// @notice This was converted from the Vyper version with the assistance of GPT-4 by ZrowGz at Pitch Foundation
+/// @notice There may be issues, especially with the type conversions.
+
+interface VotingEscrow {
+    struct LockedBalance{
+        int128 amount;
+        uint256 end;
+    }
+    function balanceOf(address) external view returns (uint256);
+    function get_last_user_slope(address) external view returns (int128);
+    function locked__end(address) external view returns (uint256);
+    function locked(address) external view returns (LockedBalance memory);
+}
+
+contract GaugeController is VotingEscrow{
+    uint256 constant WEEK = 604800;
+    uint256 constant WEIGHT_VOTE_DELAY = 10 * 86400;
+    uint256 constant MULTIPLIER = 10 ** 18;
+
+    struct Point {
+        uint256 bias;
+        uint256 slope;
+    }
+
+    struct CorrectedPoint {
+        uint256 bias;
+        uint256 slope;
+        uint256 lock_end;
+        uint256 fxs_amount;
+    }
+
+    struct VotedSlope {
+        uint256 slope;
+        uint256 power;
+        uint256 end;
+    }
+
+    function balanceOf(address) external view virtual returns (uint256) {}
+    function get_last_user_slope(address) external view virtual returns (int128) {}
+    function locked__end(address) external view virtual returns (uint256) {}
+    function locked(address) external view virtual returns (LockedBalance memory) {}
+    // struct LockedBalance {
+    //     int128 amount;
+    //     uint256 end;
+    // }
+
+    address public admin;  // Can and will be a smart contract
+    address public future_admin;  // Can and will be a smart contract
+    address public token;  // CRV token
+    address public voting_escrow;  // Voting escrow
+    int128 public n_gauge_types;
+    int128 public n_gauges;
+    mapping(int128 => string) public gauge_type_names;
+    address[1000000000] public gauges;
+    mapping(address => int128) public gauge_types_;
+    mapping(address => mapping(address => VotedSlope)) public vote_user_slopes;  // user -> gauge_addr -> VotedSlope
+    mapping(address => uint256) public vote_user_power;
+    mapping(address => mapping(address => uint256)) public last_user_vote;
+
+    mapping(address => mapping(uint256 => Point)) public points_weight;
+    mapping(address => mapping(uint256 => uint256)) public changes_weight;
+    mapping(address => uint256) public time_weight;
+
+    mapping(int128 => mapping(uint256 => Point)) public points_sum;
+    mapping(int128 => mapping(uint256 => uint256)) public changes_sum;
+    uint256[1000000000] public time_sum;
+    uint256 public time_total;
+    mapping(uint256 => uint256) public points_total;
+    mapping(int128 => mapping(uint256 => uint256)) public points_type_weight;
+    uint256[1000000000] public time_type_weight;
+    uint256 public global_emission_rate;
+
+    constructor(address _token, address _voting_escrow) {
+        require(_token != address(0), "Invalid token address");
+        require(_voting_escrow != address(0), "Invalid voting escrow address");
+        admin = msg.sender;
+        token = _token;
+        voting_escrow = _voting_escrow;
+        time_total = block.timestamp / WEEK * WEEK;
+    }
+
+    function _get_corrected_info(address addr) internal view returns (CorrectedPoint memory) {
+        address escrow = voting_escrow;
+        uint256 vefxs_balance = VotingEscrow(escrow).balanceOf(addr);
+        LockedBalance memory locked_balance = VotingEscrow(escrow).locked(addr);
+        uint256 locked_end = locked_balance.end;
+        // uint128 locked = toUint128(locked_balance.amount);
+        // uint256 locked_fxs = uint256(locked);
+        uint256 locked_fxs = uint256(uint128(locked_balance.amount));
+        uint256 corrected_slope = 0;
+        if (locked_end > block.timestamp) {
+            corrected_slope = vefxs_balance / (locked_end - block.timestamp);
+        }
+        return CorrectedPoint({
+            bias: vefxs_balance,
+            slope: corrected_slope,
+            lock_end: locked_end,
+            fxs_amount: locked_fxs
+        });
+    }
+
+    function get_corrected_info(address addr) external view returns (CorrectedPoint memory) {
+        return _get_corrected_info(addr);
+    }
+    
+    function gauge_types(address addr) external view returns (int128) {
+        int128 gauge_type = gauge_types_[addr];
+        require(gauge_type != 0, "gauge 0");
+        return gauge_type - 1;
+    }
+
+    function _get_type_weight(int128 gauge_type) internal returns (uint256) {
+        uint256 t = time_type_weight[uint256(uint128(gauge_type))];
+        if (t > 0) {
+            uint256 w = points_type_weight[gauge_type][t];
+            for (uint256 i = 0; i < 500; i++) {
+                if (t > block.timestamp) {
+                    break;
+                }
+                t += WEEK;
+                points_type_weight[gauge_type][t] = w;
+                if (t > block.timestamp) {
+                    time_type_weight[uint256(uint128(gauge_type))] = t;
+                }
+            }
+            return w;
+        } else {
+            return 0;
+        }
+    }
+    
+    function _get_sum(int128 gauge_type) internal returns (uint256) {
+        uint256 t = time_sum[uint256(uint128(gauge_type))];
+        if (t > 0) {
+            Point memory pt = points_sum[gauge_type][t];
+            for (uint256 i = 0; i < 500; i++) {
+                if (t > block.timestamp) {
+                    break;
+                }
+                t += WEEK;
+                uint256 d_bias = pt.slope * WEEK;
+                if (pt.bias > d_bias) {
+                    pt.bias -= d_bias;
+                    uint256 d_slope = changes_sum[gauge_type][t];
+                    pt.slope -= d_slope;
+                } else {
+                    pt.bias = 0;
+                    pt.slope = 0;
+                }
+                points_sum[gauge_type][t] = pt;
+                if (t > block.timestamp) {
+                    time_sum[uint256(uint128(gauge_type))] = t;
+                }
+            }
+            return pt.bias;
+        } else {
+            return 0;
+        }
+    }
+
+    // function _get_total() internal returns (uint256) {
+    //     uint256 t = time_total;
+    //     int128 _n_gauge_types = n_gauge_types;
+    //     if (t > block.timestamp) {
+    //         t -= WEEK;
+    //     }
+    //     uint256 pt = points_total[t];
+    //     for (int128 gauge_type = 0; gauge_type < 100; gauge_type++) {
+    //         if (gauge_type == _n_gauge_types) {
+    //             break;
+    //         }
+    //         _get_sum(gauge_type);
+    //         _get_type_weight(gauge_type
+
+    function _get_total() internal returns (uint256) {
+        uint256 t = time_total;
+        int128 _n_gauge_types = n_gauge_types;
+        if (t > block.timestamp) {
+            t -= WEEK;
+        }
+        uint256 pt = points_total[t];
+        for (uint256 gauge_type = 0; gauge_type < 100; gauge_type++) {
+            if (gauge_type == uint256(uint128(_n_gauge_types))) {
+                break;
+            }
+            _get_sum(int128(int256(gauge_type)));
+            _get_type_weight(int128(int256(gauge_type)));
+        }
+        for (uint256 i = 0; i < 500; i++) {
+            if (t > block.timestamp) {
+                break;
+            }
+            t += WEEK;
+            pt = 0;
+            for (uint256 gauge_type = 0; gauge_type < 100; gauge_type++) {
+                if (gauge_type == uint256(uint128(_n_gauge_types))) {
+                    break;
+                }
+                uint256 type_sum = points_sum[int128(int256(gauge_type))][t].bias;
+                uint256 type_weight = points_type_weight[int128(int256(gauge_type))][t];
+                pt += type_sum * type_weight;
+            }
+            points_total[t] = pt;
+            if (t > block.timestamp) {
+                time_total = t;
+            }
+        }
+        return pt;
+    }
+
+    function _get_weight(address gauge_addr) private returns (uint256) {
+        uint256 t = time_weight[gauge_addr];
+        if (t > 0) {
+            Point memory pt = points_weight[gauge_addr][t];
+            for (uint256 i = 0; i < 500; i++) {
+                if (t > block.timestamp) {
+                    break;
+                }
+                t += WEEK;
+                uint256 d_bias = pt.slope * WEEK;
+                if (pt.bias > d_bias) {
+                    pt.bias -= d_bias;
+                    uint256 d_slope = changes_weight[gauge_addr][t];
+                    pt.slope -= d_slope;
+                } else {
+                    pt.bias = 0;
+                    pt.slope = 0;
+                }
+                points_weight[gauge_addr][t] = pt;
+                if (t > block.timestamp) {
+                    time_weight[gauge_addr] = t;
+                }
+            }
+            return pt.bias;
+        } else {
+            return 0;
+        }
+    }
+
+    function add_gauge(address addr, int128 gauge_type, uint256 weight) external {
+        require(msg.sender == admin, "Admin only");
+        require(weight >= 0, "Weight must be non-negative");
+        require(gauge_type >= 0 && gauge_type < n_gauge_types, "Invalid gauge type");
+        require(gauge_types_[addr] == 0, "Cannot add the same gauge twice");
+
+        int128 n = n_gauges;
+        n_gauges = n + 1;
+        gauges[uint256(uint128(n))] = addr;
+        gauge_types_[addr] = gauge_type + 1;
+
+        uint256 next_time = (block.timestamp + WEEK) / WEEK * WEEK;
+
+        if (weight > 0) {
+            uint256 _type_weight = _get_type_weight(gauge_type);
+            uint256 _old_sum = _get_sum(gauge_type);
+            uint256 _old_total = _get_total();
+            points_sum[gauge_type][next_time].bias = weight + _old_sum;
+            time_sum[uint256(uint128(gauge_type))] = next_time;
+            points_total[next_time] = _old_total + _type_weight * weight;
+            time_total = next_time;
+            points_weight[addr][next_time].bias = weight;
+        }
+
+        if (time_sum[uint256(uint128(gauge_type))] == 0) {
+            time_sum[uint256(uint128(gauge_type))] = next_time;
+        }
+
+        time_weight[addr] = next_time;
+    }
+
+    function checkpoint() external {
+        _get_total();
+    }
+
+    function checkpoint_gauge(address gauge_addr) external {
+        _get_weight(gauge_addr);
+        _get_total();
+    }
+
+    function _gauge_relative_weight(address addr, uint256 time) internal view returns (uint256) {
+        uint256 t = time / WEEK * WEEK;
+        uint256 _total_weight = points_total[t];
+        if (_total_weight > 0) {
+            int128 gauge_type = gauge_types_[addr] - 1;
+            uint256 _type_weight = points_type_weight[gauge_type][t];
+            uint256 _gauge_weight = points_weight[addr][t].bias;
+            return MULTIPLIER * _type_weight * _gauge_weight / _total_weight;
+        } else { 
+            return 0;
+        }
+    }
+
+    function gauge_relative_weight(address addr, uint256 time) external view returns (uint256) {
+        return _gauge_relative_weight(addr, block.timestamp);
+    }
+
+    function gauge_relative_weight_write(address addr) external returns (uint256) {
+        _get_weight(addr);
+        _get_total();
+        return _gauge_relative_weight(addr, block.timestamp);    }
+
+    function gauge_relative_weight_write(address addr, uint256 time) external returns (uint256) {
+        _get_weight(addr);
+        _get_total();
+        return _gauge_relative_weight(addr, time);
+    }
+
+    function add_type(string memory _name, uint256 weight) external {
+        require(msg.sender == admin, "Only admin can add gauge types");
+        require(weight >= 0, "Weight must be non-negative");
+        int128 type_id = n_gauge_types;
+        gauge_type_names[type_id] = _name;
+        n_gauge_types = type_id + 1;
+        if (weight != 0) {
+            _change_type_weight(type_id, weight);
+        }
+    }
+
+    function change_type_weight(int128 type_id, uint256 weight) external {
+        require(msg.sender == admin, "Admin only");
+        require(type_id >= 0 && type_id < n_gauge_types, "Invalid gauge type");
+        _change_type_weight(type_id, weight);
+    }
+
+    function _change_type_weight(int128 type_id, uint256 weight) internal {
+        uint256 old_weight = _get_type_weight(type_id);
+        uint256 old_sum = _get_sum(type_id);
+        uint256 total_weight = _get_total();
+        uint256 next_time = (block.timestamp + WEEK) / WEEK * WEEK;
+        total_weight = total_weight + old_sum * weight - old_sum * old_weight;
+        points_total[next_time] = total_weight;
+        points_type_weight[type_id][next_time] = weight;
+        time_total = next_time;
+        time_type_weight[uint256(uint128(type_id))] = next_time;
+    }
+
+    function change_gauge_weight(address addr, uint256 weight) external {
+        require(msg.sender == admin, "Admin only");
+        _change_gauge_weight(addr, weight);
+    }
+
+    function _change_gauge_weight(address addr, uint256 weight) internal {
+        int128 gauge_type = gauge_types_[addr] - 1;
+        uint256 old_gauge_weight = _get_weight(addr);
+        uint256 type_weight = _get_type_weight(gauge_type);
+        uint256 old_sum = _get_sum(gauge_type);
+        uint256 _total_weight = _get_total();
+        uint256 next_time = (block.timestamp + WEEK) / WEEK * WEEK;
+        points_weight[addr][next_time].bias = weight;
+        time_weight[addr] = next_time;
+        uint256 new_sum = old_sum + weight - old_gauge_weight;
+        points_sum[gauge_type][next_time].bias = new_sum;
+        time_sum[uint256(uint128(gauge_type))] = next_time;
+        _total_weight = _total_weight + new_sum * type_weight - old_sum * type_weight;
+        points_total[next_time] = _total_weight;
+        time_total = next_time;
+    }
+
+    function vote_for_gauge_weights(address _gauge_addr, uint256 _user_weight) external {
+        CorrectedPoint memory corrected_point = _get_corrected_info(msg.sender);
+        uint256 slope = corrected_point.slope;
+        uint256 lock_end = corrected_point.lock_end;
+        int128 _n_gauges = n_gauges;
+        uint256 next_time = (block.timestamp + WEEK) / WEEK * WEEK;
+        require(lock_end > next_time, "!locked");
+        require((_user_weight >= 0) && (_user_weight <= 10000), "!votes");
+        require(block.timestamp >= last_user_vote[msg.sender][_gauge_addr] + WEIGHT_VOTE_DELAY, "!soon");
+        int128 gauge_type = gauge_types_[_gauge_addr] - 1;
+        require(gauge_type >= 0, "!Gauge");
+        VotedSlope memory old_slope = vote_user_slopes[msg.sender][_gauge_addr];
+        uint256 old_dt = 0;
+        if (old_slope.end > next_time) {
+            old_dt = old_slope.end - next_time;
+        }
+        uint256 old_bias = old_slope.slope * old_dt;
+        VotedSlope memory new_slope = VotedSlope({
+            slope: slope * _user_weight / 10000,
+            power: _user_weight,
+            end: lock_end
+        });
+        uint256 new_dt = lock_end - next_time;
+        uint256 new_bias = new_slope.slope * new_dt;
+        uint256 power_used = vote_user_power[msg.sender];
+        power_used = power_used + new_slope.power - old_slope.power;
+        vote_user_power[msg.sender] = power_used;
+        require((power_used >= 0) && (power_used <= 10000), '!power');
+        uint256 old_weight_bias = _get_weight(_gauge_addr);
+        uint256 old_weight_slope = points_weight[_gauge_addr][next_time].slope;
+        uint256 old_sum_bias = _get_sum(gauge_type);
+        uint256 old_sum_slope = points_sum[gauge_type][next_time].slope;
+
+        points_weight[_gauge_addr][next_time].bias = (old_weight_bias + new_bias > old_bias) ? old_weight_bias + new_bias - old_bias : 0;
+        points_sum[gauge_type][next_time].bias = (old_sum_bias + new_bias > old_bias) ? old_sum_bias + new_bias - old_bias : 0;
+        if (old_slope.end > next_time) {
+            points_weight[_gauge_addr][next_time].slope = (old_weight_slope + new_slope.slope > old_slope.slope) ? old_weight_slope + new_slope.slope - old_slope.slope : 0;
+            points_sum[gauge_type][next_time].slope = (old_sum_slope + new_slope.slope > old_slope.slope) ? old_sum_slope + new_slope.slope - old_slope.slope : 0;
+        } else {
+            points_weight[_gauge_addr][next_time].slope += new_slope.slope;
+            points_sum[gauge_type][next_time].slope += new_slope.slope;
+        }
+        if (old_slope.end > block.timestamp) {
+            changes_weight[_gauge_addr][old_slope.end] -= old_slope.slope;
+            changes_sum[gauge_type][old_slope.end] -= old_slope.slope;
+        }
+        changes_weight[_gauge_addr][new_slope.end] += new_slope.slope;
+        changes_sum[gauge_type][new_slope.end] += new_slope.slope;
+        _get_total();
+        vote_user_slopes[msg.sender][_gauge_addr] = new_slope;
+        last_user_vote[msg.sender][_gauge_addr] = block.timestamp;
+    }
+
+    function get_gauge_weight(address addr) public view returns (uint256) {
+        /**
+        * @notice Get current gauge weight
+        * @param addr Gauge address
+        * @return Gauge weight
+        */
+        return points_weight[addr][time_weight[addr]].bias;
+    }
+
+    function get_type_weight(int128 type_id) external view returns (uint256) {
+        /**
+        * @notice Get current type weight
+        * @param type_id Type id
+        * @return Type weight
+        */
+        return points_type_weight[type_id][time_type_weight[uint256(uint128(type_id))]];
+    }
+
+    function get_total_weight() external view returns (uint256) {
+        /**
+        * @notice Get current total (type-weighted) weight
+        * @return Total weight
+        */
+        return points_total[time_total];
+    }
+
+    function get_weights_sum_per_type(int128 type_id) external view returns (uint256) {
+        /**
+        * @notice Get sum of gauge weights per type
+        * @param type_id Type id
+        * @return Sum of gauge weights
+        */
+        return points_sum[type_id][time_sum[uint256(uint128(type_id))]].bias;
+    }
+
+    function change_global_emission_rate(uint256 new_rate) external {
+        /**
+        * @notice Change FXS emission rate
+        * @param new_rate new emission rate (FXS per second)
+        */
+        require(msg.sender == admin, "Only admin can change global emission rate");
+        global_emission_rate = new_rate;
+    }
+
+}

--- a/src/hardhat/contracts/Staking/FraxUnifiedFarmTemplate_V2.sol
+++ b/src/hardhat/contracts/Staking/FraxUnifiedFarmTemplate_V2.sol
@@ -212,8 +212,8 @@ contract FraxUnifiedFarmTemplate_V2 is OwnedV2, ReentrancyGuardV2 {
         max_locked_stakes = 12;
 
         // Sync the first period finish here with the gauge's 
-        // periodFinish = IFraxGaugeController(gaugeControllers[0]).time_total();
-        periodFinish = IFraxGaugeController(0x3669C421b77340B2979d1A00a792CC2ee0FcE737).time_total();
+        periodFinish = IFraxGaugeController(gaugeControllers[0]).time_total();
+        // periodFinish = IFraxGaugeController(0x3669C421b77340B2979d1A00a792CC2ee0FcE737).time_total();
     }
 
     /* ============= VIEWS ============= */


### PR DESCRIPTION
## The current version to use is: FraxFamilialGaugeDistributor.sol

The Familial Gauge was switched to act as a Token Manager for FXS.
- Rather than having it emulate the GaugeController functionality, it only `distributesReward`
- It loops through each child gauge & sets them appropriately each week

This also contains a the FraxGaugeController converted to solidity from Vyper (with the help of GPT-4 & some cleanup), but this could be substantially optimized. **This converted version is unaudited & untested! Use at your own risk!** It was utilized for testing purposes ONLY!

The file `FraxFamilialPitchGauge.sol` was the version where it emulated the ABI of both the Gauge Controller & FXS Rewards Distributor. This is an incomplete/untested file & was replaced by `FraxFamilialGaugeDistributor.sol`